### PR TITLE
Add Dockerfile and GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-publish:
+    env:
+      SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up QEMU for Docker
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into the container registry
+        if: ${{ env.SHOULD_PUSH_IMAGE == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=sha
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ env.SHOULD_PUSH_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG app_dir="/home/go/app"
+
+
+# * Building the application
+FROM golang:1.22-alpine3.20 AS build
+ARG app_dir
+
+WORKDIR ${app_dir}
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+	--mount=type=bind,source=go.sum,target=go.sum \
+	--mount=type=bind,source=go.mod,target=go.mod \
+	go mod download -x
+
+COPY . .
+ARG BUILD_STRING=pretendo.sdsw.docker
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+	CGO_ENABLED=0 go build -ldflags "-X 'main.serverBuildString=${BUILD_STRING}'" -v -o ${app_dir}/build/server
+
+
+# * Running the final application
+FROM alpine:3.20 AS final
+ARG app_dir
+WORKDIR ${app_dir}
+
+RUN addgroup go && adduser -D -G go go
+
+RUN mkdir -p ${app_dir}/log && chown go:go ${app_dir}/log
+
+USER go
+
+COPY --from=build ${app_dir}/build/server ${app_dir}/server
+
+CMD [ "./server" ]


### PR DESCRIPTION
- Added dockerfile
- Added CI for building images:
  - When publishing, it will publish to github packages for this repo.
  - Push to master: build and publish an image with `latest` and `sha-<GIT_HASH>` tags
  - Push to dev: build and publish an image with `edge` and `sha-<GIT_HASH>` tags
  - Push to any branch: only builds, doesn't publish
  - Any PR: only builds, doesn't publish
  - Workflow can be dispatched manually, which will build and publish with `sha-<GIT_HASH>` tag.
